### PR TITLE
Add reflective essay on Hong Kong vaccination data

### DIFF
--- a/vibeCoding101/Part4GovEnquiryReflectEssay/essay2.md
+++ b/vibeCoding101/Part4GovEnquiryReflectEssay/essay2.md
@@ -1,0 +1,13 @@
+Date: 2025-10-17
+
+Introduction 
+
+When I am doing with my project, I found that there are different points of the data about Hong Kong vaccination.
+
+Main Body
+
+I found Hong Kong’s data transparency uneven. High-level reports, summary statistics and many datasets are openly published online, but granular, case‑level or contract-specific records often require a formal request under the Code on Access to Information. For example, budget summaries and published indicators were easy to locate, whereas procurement line‑items and individual case files likely need a formal enquiry. Drafting the enquiry forced me to define precise variables, time ranges and the legal basis for the request—identifying these requirements was the hardest part. The AI agent helped substantially with structure, tone and concise wording of the letter and with locating relevant pages on access.gov.hk, but it sometimes missed jurisdictional nuance that my course materials clarified. Compared with the customized chatbot tutor I used earlier, this AI was better at drafting formal text but less effective at pedagogical scaffolding. Through this collaboration I improved formal writing, scope‑definition and prompt engineering skills.
+
+Conclusion
+
+The requested government data would strengthen empirical analysis and policy recommendations; if a request is denied I will rely on aggregated open datasets, published reports, or simulated sensitivity analyses. I will continue using AI as a drafting assistant while verifying legal and contextual details myself. (33 words)


### PR DESCRIPTION
Added a reflective essay discussing data transparency in Hong Kong's vaccination records and the use of AI in drafting formal requests.